### PR TITLE
Added links to awesome-norns + format 

### DIFF
--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -4,11 +4,14 @@ title: resources
 permalink: /resources/
 ---
 
+
 # norns
 - [lines](https://llllllll.co) (main monome forum)
 - [@neauoire's norns tutorial](https://llllllll.co/t/norns-tutorial/23241)
 - [norns walkthrough: WIFI + maiden](https://vimeo.com/436460489)
 - [awesome-norns](https://github.com/p3r7/awesome-monome-norns/blob/main/README.md)
+
+
 #  lua
  - [lua cheatsheet](https://devhints.io/lua) (great for learning lua)
  - [official monome norns studies](https://monome.org/docs/norns/study-1/) (your guide to guiding)
@@ -16,6 +19,8 @@ permalink: /resources/
  - [official monome norns github](https://github.com/monome/norns)
  - [lua documentation](http://www.lua.org/manual/5.4/) (codex)
  - [Development: General](https://github.com/p3r7/awesome-monome-norns/blob/main/README.md#development-general) and [lua libs index](https://github.com/p3r7/awesome-monome-norns/blob/main/README.md#lua-libs) sections in awesome-norns
+
+
 #  supercollider
 
 - [youtube playlist for an overview](https://youtu.be/yRzsOOiJ_p4)
@@ -30,16 +35,19 @@ permalink: /resources/
 - [supercollider server explained](https://doc.sccode.org/Guides/ClientVsServer.html)
 - [j concepts in supercollider](https://doc.sccode.org/Guides/J-concepts-in-SC.html)
 - [how to use an interpreter with supercollider ](https://doc.sccode.org/Guides/How-to-Use-the-Interpreter.html)
+
 ### managing audio
 - [node](https://doc.sccode.org/Classes/Node.html)
 - [bus](https://doc.sccode.org/Classes/Bus.html)
 
 ---
+
 ### useful tips for supercollider
 - select any class or method name and press ctl+D for a help page, usually containing  example code and links to related classes and overview pages
 - select any class name and press ctl+I to inspect the source code for the class. (+repeat.) often this just ends up being a light FFI wrapper , however many times it reveals how many sclang classes are actually implemented in sclang, and drilling down in this process reveals many powerful methods that  might otherwise be overlooked.
 
 ---
+
 
 #  softcut
 

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -4,27 +4,30 @@ title: resources
 permalink: /resources/
 ---
 
-# norns 
+# norns
 - [lines](https://llllllll.co) (main monome forum)
 - [@neauoire's norns tutorial](https://llllllll.co/t/norns-tutorial/23241)
 - [norns walkthrough: WIFI + maiden](https://vimeo.com/436460489)
+- [awesome-norns](https://github.com/p3r7/awesome-monome-norns/blob/main/README.md)
 #  lua
  - [lua cheatsheet](https://devhints.io/lua) (great for learning lua)
  - [official monome norns studies](https://monome.org/docs/norns/study-1/) (your guide to guiding)
- - [official monome norns docs](https://monome.org/docs/norns/) 
+ - [official monome norns docs](https://monome.org/docs/norns/)
  - [official monome norns github](https://github.com/monome/norns)
  - [lua documentation](http://www.lua.org/manual/5.4/) (codex)
+ - [Development: General](https://github.com/p3r7/awesome-monome-norns/blob/main/README.md#development-general) and [lua libs index](https://github.com/p3r7/awesome-monome-norns/blob/main/README.md#lua-libs) sections in awesome-norns
 #  supercollider
 
 - [youtube playlist for an overview](https://youtu.be/yRzsOOiJ_p4)
+- [engines index in awesome-norns](https://github.com/p3r7/awesome-monome-norns/blob/main/README.md#supercollider-engines)
 
 ## language fundamentals
 - [written tutorial](https://composerprogrammer.com/teaching/supercollider/sctutorial/tutorial.html#chapter1)
 - [first steps to colliding atoms](https://doc.sccode.org/Tutorials/Getting-Started/02-First-Steps.html)
-- [how to get your code to play](https://doc.sccode.org/Reference/play.html) 
-- [what is a function?](https://doc.sccode.org/Reference/Functions.html) 
-- [if , while , for , etc](https://doc.sccode.org/Reference/Control-Structures.html) 
-- [supercollider server explained](https://doc.sccode.org/Guides/ClientVsServer.html) 
+- [how to get your code to play](https://doc.sccode.org/Reference/play.html)
+- [what is a function?](https://doc.sccode.org/Reference/Functions.html)
+- [if , while , for , etc](https://doc.sccode.org/Reference/Control-Structures.html)
+- [supercollider server explained](https://doc.sccode.org/Guides/ClientVsServer.html)
 - [j concepts in supercollider](https://doc.sccode.org/Guides/J-concepts-in-SC.html)
 - [how to use an interpreter with supercollider ](https://doc.sccode.org/Guides/How-to-Use-the-Interpreter.html)
 ### managing audio


### PR DESCRIPTION
I'm not 100% sure about including all those new links.

There sure is some overlap between this resources page and [awesome-monome-norns](https://github.com/p3r7/awesome-monome-norns/blob/main/README.md) but they don't have the same scope:
-  `awesome-monome-norns` lists only norns-specific resources and aims at being exhaustive
-  `study.norns.online/resources/` is broader in scope, listing generic Lua & supercollider resources and aims (I guess) at being succinct